### PR TITLE
Contactpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/app/assets/stylesheets/pages/_contact.scss
+++ b/app/assets/stylesheets/pages/_contact.scss
@@ -2,21 +2,16 @@
 
 .contact-page-container {
   width: 100vw;
-  // margin: 0 auto;
   min-height: 100vh;
-  // display: flex;
-  // margin-bottom: 100px;
 }
 
 .contact-elements-container {
-  // width: 100%;
   display: flex;
   margin: 0 auto;
   align-items: center;
   justify-content: center;
   flex-direction: column;
   margin-top: 125px;
-  // margin-bottom: 100px;
 }
 
 .contact-text-container {
@@ -36,9 +31,7 @@
 
 .contact-card-container {
   display: flex;
-  // flex-direction: row;
   align-items: center;
-  // margin: 0 auto;
   flex-grow: 1;
   justify-content: space-between;
 }
@@ -46,21 +39,15 @@
 .social-media-links {
   display: flex;
   flex-direction: row;
-  // margin: 0 auto;
   align-items: center;
   justify-content: space-between;
   flex-grow: 1;
-  // margin: 0;
 }
 
 .contact-card {
   border-radius: 3px;
-  // color: $even-darker-pink;
   color: $darkest-pink;
   background-color: $white;
-  // background-color: $barbie-pink;
-  // text-decoration: none;
-  // border: 2px solid black;
   margin: 16px;
   text-align: center;
   justify-content: center;
@@ -68,16 +55,13 @@
   padding: 20px;
   font-size: 20px;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
-  // display: inline-block;
   flex-grow: 1;
 
   a {
     text-decoration: none;
-    // color: $even-darker-pink;
     color: $darkest-pink;
     transition: 0.3s;
     padding: 16px;
-    // padding-left: 8px;
     padding-left: 0;
     margin: 0;
     margin-top: 8px;
@@ -85,19 +69,15 @@
   }
 
   a:hover {
-    // font-size: 22px;
     color: $soft-light-pink;
-    // font-weight: bolder;
   }
 
   i {
-    // color: $even-darker-pink;
     color: $darkest-pink;
     padding-right: 8px;
   }
 
   p {
-    // color: $even-darker-pink;
     color: $darkest-pink;
   }
 }

--- a/app/assets/stylesheets/pages/_contact.scss
+++ b/app/assets/stylesheets/pages/_contact.scss
@@ -166,3 +166,35 @@
   font-size: 20px;
   text-align: center;
 }
+
+@media (max-width: 576px) {
+  .contact-elements-container {
+    margin-top: 100px;
+  }
+
+  .contact-success-container {
+    margin-bottom: 100px;
+  }
+
+  #contact-success-notice {
+    margin-bottom: 100px;
+  }
+}
+
+@media (max-width: 400px) {
+  .contact-elements-container {
+    margin-top: 75px;
+  }
+
+  .contact-text-container h3 {
+    margin-bottom: 20px;
+  }
+
+  .contact-success-container {
+    margin-bottom: 125px;
+  }
+
+  #contact-success-notice {
+    margin-bottom: 100px;
+  }
+}

--- a/app/assets/stylesheets/pages/_contact.scss
+++ b/app/assets/stylesheets/pages/_contact.scss
@@ -1,1 +1,99 @@
 // contact page styling
+
+.contact-page-container {
+  width: 100vw;
+  // margin: 0 auto;
+  min-height: 100vh;
+  // display: flex;
+}
+
+.contact-elements-container {
+  // width: 100%;
+  display: flex;
+  margin: 0 auto;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  margin-top: 125px;
+}
+
+.contact-text-container {
+  align-items: center;
+  justify-content: center;
+
+  h3 {
+    color: $darkest-pink;
+    background-color: $white;
+    text-align: center;
+    border-radius: 3px;
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 16px;
+    margin: 24px;
+  }
+}
+
+.contact-card-container {
+  display: flex;
+  // flex-direction: row;
+  align-items: center;
+  // margin: 0 auto;
+  flex-grow: 1;
+  justify-content: space-between;
+}
+
+.social-media-links {
+  display: flex;
+  flex-direction: row;
+  // margin: 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  flex-grow: 1;
+  // margin: 0;
+}
+
+.contact-card {
+  border-radius: 3px;
+  color: $even-darker-pink;
+  background-color: $white;
+  // background-color: $barbie-pink;
+  // text-decoration: none;
+  // border: 2px solid black;
+  margin: 16px;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  font-size: 20px;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+  // display: inline-block;
+  flex-grow: 1;
+
+  a {
+    text-decoration: none;
+    // color: $even-darker-pink;
+    color: $darkest-pink;
+    transition: 0.3s;
+    padding: 16px;
+    // padding-left: 8px;
+    padding-left: 0;
+    margin: 0;
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+
+  a:hover {
+    // font-size: 22px;
+    color: $soft-light-pink;
+    // font-weight: bolder;
+  }
+
+  i {
+    color: $even-darker-pink;
+    padding-right: 8px;
+  }
+
+  p {
+    // color: $even-darker-pink;
+    color: $darkest-pink;
+  }
+}

--- a/app/assets/stylesheets/pages/_contact.scss
+++ b/app/assets/stylesheets/pages/_contact.scss
@@ -5,6 +5,7 @@
   // margin: 0 auto;
   min-height: 100vh;
   // display: flex;
+  // margin-bottom: 100px;
 }
 
 .contact-elements-container {
@@ -15,6 +16,7 @@
   justify-content: center;
   flex-direction: column;
   margin-top: 125px;
+  // margin-bottom: 100px;
 }
 
 .contact-text-container {
@@ -53,7 +55,8 @@
 
 .contact-card {
   border-radius: 3px;
-  color: $even-darker-pink;
+  // color: $even-darker-pink;
+  color: $darkest-pink;
   background-color: $white;
   // background-color: $barbie-pink;
   // text-decoration: none;
@@ -88,7 +91,8 @@
   }
 
   i {
-    color: $even-darker-pink;
+    // color: $even-darker-pink;
+    color: $darkest-pink;
     padding-right: 8px;
   }
 
@@ -96,4 +100,69 @@
     // color: $even-darker-pink;
     color: $darkest-pink;
   }
+}
+
+#contact-form {
+  margin: 0 auto;
+  margin-bottom: 125px;
+  margin-top: 50px;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  .form-control {
+    background-color: $white;
+    color: $even-darker-pink;
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .form-label {
+    color: $darkest-pink;
+    margin-top: 4px;
+  }
+
+  #contact_message {
+    min-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 32px;
+    color: $even-darker-pink;
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+  }
+
+  .form-button {
+    display: flex;
+    justify-content: center;
+  }
+
+  .btn {
+    background-color: $darkest-pink;
+    color: $white;
+    border: 1px solid $even-darker-pink;
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 10px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    border-radius: 3px;
+    font-size: 18px;
+    transition: 0.3s;
+  }
+
+  .btn:hover {
+    background-color: $white;
+    color: $darkest-pink;
+  }
+}
+
+.contact-success-container {
+  margin: 0 auto;
+  margin-top: 50px;
+  display: flex;
+  justify-content: center;
+}
+
+#contact-success-notice {
+  color: $even-darker-pink;
+  font-size: 20px;
+  text-align: center;
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,25 @@ class PagesController < ApplicationController
   def contact
   end
 
+  def send_contact_email
+    @name = strong_params[:name]
+    @title = strong_params[:title]
+    @email = strong_params[:email]
+    @message = strong_params[:message]
+
+    if @name.present? && @title.present? && @email.present? && @message.present?
+      ContactMailer.send_contact_email(@name, @title, @email, @message).deliver_now
+
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace('contact-form', partial: 'pages/contact_success') }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.append('contact-form', partial: 'pages/contact_failure') }
+      end
+    end
+  end
+
   def resume
     @techstack = ["Ruby", "Ruby On Rails", "HTML5", "CSS/SCSS", "Javascript", "Git", "Github", "TDD", "Z-Shell", "Visual Studio Code", "Ubuntu"]
     @other = ["Python", "SQL & PostgreSQL", "Heroku", "Stimulus", "Bootstrap", "Redis", "Cloudinary", "Action Cable", "Websocket", "Figma"]
@@ -18,5 +37,11 @@ class PagesController < ApplicationController
   end
 
   def projects
+  end
+
+  private
+
+  def strong_params
+    params.require(:contact).permit(:name, :title, :email, :message)
   end
 end

--- a/app/javascript/controllers/contact_controller.js
+++ b/app/javascript/controllers/contact_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="contact"
+export default class extends Controller {
+  // connect() {
+  // }
+
+  static targets = [ "form" ]
+
+  toggleForm() {
+    const form = document.getElementById('contact-form');
+    if (form.style.display === "none") {
+      form.style.display = "block";
+    } else {
+      form.style.display = "none";
+    }
+  }
+
+  preventDefault(event) {
+    event.preventDefault();
+  }
+
+  submitForm(event) {
+    event.preventDefault();
+    const form = document.getElementById('contact-form');
+    const formData = new FormData(form);
+
+    if (!formData.get('name') || !formData.get('title') || !formData.get('email') || !formData.get('message')) {
+      alert('Please fill in all fields.');
+      return;
+    }
+
+    Rails.ajax({
+      url: form.action,
+      type: "POST",
+      data: formData,
+      success: () => {
+        form.innerHTML = '<p>Thanks, your message has been sent!</p>';
+      },
+      error: () => {
+        alert('There was an error sending your message. Please ensure all fields have been completed and try again.');
+      }
+    });
+  }
+}

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "beth.codes1@gmail.com"
   layout "mailer"
 end

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,0 +1,12 @@
+class ContactMailer < ApplicationMailer
+  default to: 'beth.codes1@gmail.com'
+
+  def send_contact_email(name, title, email, message)
+    @name = name
+    @title = title
+    @message = message
+    @from_email = email
+
+    mail(from: @from_email, subject: "New Contact Form Message: #{@title}")
+  end
+end

--- a/app/views/contact_mailer/send_contact_email.html.erb
+++ b/app/views/contact_mailer/send_contact_email.html.erb
@@ -1,0 +1,5 @@
+<p>You have a new contact form submission:</p>
+<p><strong>Name:</strong> <%= @name %></p>
+<p><strong>Email:</strong> <%= @from_email %></p>
+<p><strong>Message Title:</strong> <%= @title %></p>
+<p><strong>Message:</strong> <%= @message %></p>

--- a/app/views/pages/_contact_failure.html.erb
+++ b/app/views/pages/_contact_failure.html.erb
@@ -1,0 +1,3 @@
+<script>
+  alert('There was an error sending your message. Please ensure all fields have been completed and try again.');
+</script>

--- a/app/views/pages/_contact_success.html.erb
+++ b/app/views/pages/_contact_success.html.erb
@@ -1,0 +1,3 @@
+<div class="contact-success-container col-8">
+  <p id="contact-success-notice">Thanks, your message has been sent! I'll respond to you as soon as possible ☺️</p>
+</div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -2,38 +2,51 @@
 <div class="contact-page-container">
   <div class="contact-elements-container col-12 col-md-10">
     <span class="contact-text-container col-12 col-md-10">
-      <h3>
-        Reach out to me easily via any of the below:
-      </h3>
+      <h3>Reach out to me easily via any of the below:</h3>
     </span>
     <div class="contact-card-container col-12 col-md-10">
       <div class="row social-media-links col-10">
-
-
         <span class="contact-card col-10 col-md-5">
           <i class="fa-brands fa-square-github"></i>
-          <%= link_to "GitHub: BethGeast", "https://github.com/BethGeast", target: "_blank" %>
+          <%= link_to "GitHub", "https://github.com/BethGeast", target: "_blank" %>
         </span>
-
 
         <span class="contact-card col-10 col-md-5">
           <i class="fa-brands fa-linkedin"></i>
-          <%= link_to "LinkedIn: bethgeast", "https://www.linkedin.com/in/bethgeast/", target: "_blank" %>
+          <%= link_to "LinkedIn", "https://www.linkedin.com/in/bethgeast/", target: "_blank" %>
         </span>
-
 
         <span class="contact-card col-10 col-md-5">
           <i class="fa-solid fa-at"></i>
-          <%= 'beth.codes1@gmail.com' %>
-          <%# <p>  beth.codes1@gmail.com</p> %>
+          <%= link_to "Email", "mailto:beth.codes1@gmail.com", target: "_blank" %>
         </span>
 
-
-        <span class="contact-card col-10 col-md-5">
+        <span class="contact-card col-10 col-md-5" data-controller="contact" data-action="click->contact#toggleForm">
           <i class="fa-solid fa-envelope"></i>
-          <%= link_to "Drop me a message", "mailto:beth.codes1@gmail.com", target: "_blank" %>
+          <%# <%= link_to "Drop me a message", "#", data-action="click->contact#preventDefault" %>
+          <a href="#" data-action="click->contact#preventDefault">Drop me a message</a>
         </span>
       </div>
     </div>
+  </div>
+
+  <div id="contact-form" class="container col-10 col-md-8" style="display: none;">
+    <%= simple_form_for :contact, url: send_contact_email_path, data: { turbo_frame: "_top" } do |f| %>
+      <div class="form-group">
+        <%= f.input :name, required: true, label: 'Your Name' %>
+      </div>
+      <div class="form-group">
+        <%= f.input :title, required: true, label: 'Message Title' %>
+      </div>
+      <div class="form-group">
+        <%= f.input :email, required: true, label: 'Your Contact Email Address' %>
+      </div>
+      <div class="form-group">
+        <%= f.input :message, as: :text, required: true, label: 'Your Message' %>
+      </div>
+      <div class="form-button">
+        <%= f.button :submit, 'Send Message', data: { action: "contact#submitForm" } %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,2 +1,39 @@
-<h1>Contact</h1>
-<h3>pages#contact</h3>
+<%# pages#contact %>
+<div class="contact-page-container">
+  <div class="contact-elements-container col-12 col-md-10">
+    <span class="contact-text-container col-12 col-md-10">
+      <h3>
+        Reach out to me easily via any of the below:
+      </h3>
+    </span>
+    <div class="contact-card-container col-12 col-md-10">
+      <div class="row social-media-links col-10">
+
+
+        <span class="contact-card col-10 col-md-5">
+          <i class="fa-brands fa-square-github"></i>
+          <%= link_to "GitHub: BethGeast", "https://github.com/BethGeast", target: "_blank" %>
+        </span>
+
+
+        <span class="contact-card col-10 col-md-5">
+          <i class="fa-brands fa-linkedin"></i>
+          <%= link_to "LinkedIn: bethgeast", "https://www.linkedin.com/in/bethgeast/", target: "_blank" %>
+        </span>
+
+
+        <span class="contact-card col-10 col-md-5">
+          <i class="fa-solid fa-at"></i>
+          <%= 'beth.codes1@gmail.com' %>
+          <%# <p>  beth.codes1@gmail.com</p> %>
+        </span>
+
+
+        <span class="contact-card col-10 col-md-5">
+          <i class="fa-solid fa-envelope"></i>
+          <%= link_to "Drop me a message", "mailto:beth.codes1@gmail.com", target: "_blank" %>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -4,7 +4,7 @@
     <span class="contact-text-container col-12 col-md-10">
       <h3>Reach out to me easily via any of the below:</h3>
     </span>
-    <div class="contact-card-container col-12 col-md-10">
+    <div class="contact-card-container col-10 col-md-10">
       <div class="row social-media-links col-10">
         <span class="contact-card col-10 col-md-5">
           <i class="fa-brands fa-square-github"></i>
@@ -24,7 +24,7 @@
         <span class="contact-card col-10 col-md-5" data-controller="contact" data-action="click->contact#toggleForm">
           <i class="fa-solid fa-envelope"></i>
           <%# <%= link_to "Drop me a message", "#", data-action="click->contact#preventDefault" %>
-          <a href="#" data-action="click->contact#preventDefault">Drop me a message</a>
+          <a href="#" data-action="click->contact#preventDefault">Message me</a>
         </span>
       </div>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,8 +36,27 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # # Don't care if the mailer can't send.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Configure mailer to use Gmail SMTP server
+  config.action_mailer.delivery_method = :smtp
+
+  # Configure SMTP settings
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "gmail.com",
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_PASSWORD"]
+  }
+
+  # Ensure emails are delivered in development for testing purposes
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,25 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Configure the mailer to use gmail's SMTP server
+  config.action_mailer.delivery_method = :smtp
+
+  # Configure SMTP settings
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: "gmail.com",
+    authentication: "plain",
+    enable_starttls_auto: true,
+    user_name: ENV["GMAIL_USERNAME"],
+    password: ENV["GMAIL_PASSWORD"]
+  }
+
+  # Ensure emails are delivered in production
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: "REPLACE WITH DOMAIN WHEN PURCHASED"}
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get "contact", to: "pages#contact"
   get "resume", to: "pages#resume"
   get "projects", to: "pages#projects"
+  post "send_contact_email", to: "pages#send_contact_email"
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/test/mailers/contact_mailer_test.rb
+++ b/test/mailers/contact_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ContactMailerTest < ActionMailer::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/mailers/previews/contact_mailer_preview.rb
+++ b/test/mailers/previews/contact_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/contact_mailer
+class ContactMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
- adds "contact" page content
- adds links to LinkedIn and Github accounts (both links opening in new tab), an email link which when clicked opens user's email account with a generated new email template pre-filled with website's business email address in the "to" field
- also adds a "message me" link -> when clicked this toggles a contact form to open up below on the same page. Javascript used for the toggle. If any of the form fields are left blank then turbo notice prompts user to ensure they complete all fields. If submit is successful (if all fields are completed), then using javascript and AJAX, the form is replaced by a "thank you, your message has been sent" notice, without a page reload. Controller edited to ensure strong params are used for the form fields. When form is submitted, the form entries are injected into a basic email format and automatically sent to the website's business email by using rails mailer. Development environment updated to allow emails to be sent whilst submitting form on localhost so that functionality could be thoroughly tested before site is pushed to production environment.
- styling completed for every aspect of the page
- styling also updated with media queries to ensure page is fully responsive across different device sizes.

![image](https://github.com/user-attachments/assets/b8f5de1d-f0d1-43a7-a310-9bcaa1fc42c1)


![image](https://github.com/user-attachments/assets/84c34576-a18d-438d-8bd0-a7c59fe2ad89)


![image](https://github.com/user-attachments/assets/364293cf-9a06-46e2-b12d-354e4be48be6)


![image](https://github.com/user-attachments/assets/1fab11e6-a834-4c76-a415-5d5cccac9080)


![image](https://github.com/user-attachments/assets/1cb625b2-d388-4b54-93b0-f983c58ebd05)
