### PR TITLE
Projectspage

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -21,10 +21,10 @@ $soft-light-pink: #ffbbff;
 $washed-pink: #eed7ee;
 $lilac-pink: #f4c7ff;
 $white: #ffffff;
-$salmon: #d4919b;
+// $salmon: #d4919b;
 $button-pink: #f4dcea;
 $faint-pink: #ffeff1;
 $background: #f3cfda;
-$maybe-red: #a60b3c;
+// $maybe-red: #a60b3c;
 
 // $darktheme-pink: #211e1e;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -28,12 +28,9 @@
 }
 
 #intro-card {
-  // color: $white;
   color: $darkest-pink;
   background-color: $white;
   text-align: center;
-  // background: $darkest-pink;
-  // background: linear-gradient(to right, $darkest-pink 96%, $hot-pink 100%);
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
   flex: 1 1 auto;
   height: auto;

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -93,7 +93,6 @@
   display: flex;
   justify-content: end;
   align-items: center;
-  // color: $darkest-pink;
 }
 
 .link-right-extended {
@@ -103,9 +102,6 @@
 }
 
 .source-link {
-  // display: flex;
-  // align-items: center;
-  // gap: 8px;
   color: $darkest-pink;
   transition: 0.3s ease;
   text-decoration: none;
@@ -173,51 +169,57 @@
   width: 100%;
   max-width: 600px;
   margin: 20px auto;
-  background-color: black;
+  background-color: rgb(15, 15, 15);
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  // cursor: pointer;
   position: relative;
-  // transition: transform 0.3s ease;
 }
 
-// .carousel-container:hover img {
-//   transform: scale(1.05);
+#gigbuddyCarousel, #gigbuddyModalCarousel, #dogbnbCarousel, #dogbnbModalCarousel {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+// #gigbuddyModalCarousel {
+//   width: 100%;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
 // }
 
-#gigbuddyCarousel {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
+// #dogbnbCarousel {
+//   width: 100%;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+// }
 
-#gigbuddyModalCarousel {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
+// #dogbnbModalCarousel {
+//   width: 100%;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+// }
 
 .carousel-inner {
   cursor: pointer;
   transition: transform 0.3s ease;
   width: 90%;
-  // height: 100%;
 }
 
 .carousel-inner:hover img {
   transform: scale(1.05);
-  // border: none;
 }
 
 .carousel-item img {
   height: 400px;
   width: auto;
   object-fit: contain;
-  background-color: black;
+  background-color: rgb(15, 15, 15);
 }
 
 .modal-body .carousel-item:hover img {
@@ -238,7 +240,11 @@
 }
 
 .carousel-control-next {
-  right:10px;
+  right: 10px;
+}
+
+.carousel-control-prev-icon, .carousel-control-next-icon {
+  color: $white;
 }
 
 .modal {
@@ -246,13 +252,13 @@
 }
 
 .modal-body {
-  background-color: black;
+  background-color: rgb(15, 15, 15);
 
   img {
     max-width: 100%;
     height: 80vh;
     object-fit: contain;
-    background-color: black;
+    background-color: rgb(15, 15, 15);
   }
 }
 
@@ -264,22 +270,32 @@
   padding: 10px;
 }
 
+.carousel-caption.custom-caption-dogbnb {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  text-align: left;
+  padding: 0;
+}
+
 .carousel-caption h5 {
   margin: 0;
   font-size: 18px;
+  color: $hot-pink;
 }
 
 .carousel-caption p {
   margin: 5px 0 0;
   font-size: 14px;
+  color: $faint-pink;
 }
-// .carousel-control-prev-icon, .carousel-control-next-icon {
-//   filter: invert(100%);
-// }
 
-
-
-
+.modal-header {
+  background: $darkest-pink;
+  background: -webkit-linear-gradient(90deg, $darkest-pink 0%, $hot-pink 25%, $barbie-pink 50%, $button-pink 75%, $white 100%);
+  background: linear-gradient(90deg, $darkest-pink 0%, $hot-pink 25%, $barbie-pink 50%, $button-pink 75%, $white 100%);
+  border-bottom: none;
+}
 
 @media (max-width: 1000px) {
   .source-link {
@@ -289,10 +305,6 @@
   .source-link-reverse {
     text-align: center;
   }
-
-  // .link-right-extended {
-  //   justify-content: center;
-  // }
 }
 
 @media (max-width: 800px) {
@@ -400,19 +412,4 @@
   .page-title-projects h3 {
     font-size: 20px;
   }
-
-  // .projects-card {
-  //   padding-top: 1rem;
-  //   padding-bottom: 1rem;
-  //   padding-left: 1.5rem;
-  //   padding-right: 1.5rem;
-
-  //   ul {
-  //     padding-left: 1rem;
-  //   }
-  // }
-
-  // .source-link {
-  //   font-size: 12px;
-  // }
 }

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -179,6 +179,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.3s ease;
+}
+
+.carousel-container:hover img {
+  transform: scale(1.05);
 }
 
 .carousel-item img {
@@ -186,12 +193,42 @@
   width: auto;
   object-fit: contain;
   background-color: black;
-  cursor: pointer;
-  transition: transform 0.3s ease;
+  // cursor: pointer;
+  // transition: transform 0.3s ease;
 
-  &:hover {
-    transform: scale(1.05);
-  }
+  // &:hover {
+  //   transform: scale(1.05);
+  // }
+}
+
+// .modal-body .carousel-item img:hover {
+//   transform: none;
+// }
+
+// .carousel-item:hover img {
+//   transform: scale(1.05);
+//   transition: transform 0.3s ease;
+// }
+
+.modal-body .carousel-item:hover img {
+  transform: none;
+}
+
+.carousel-control-prev, .carousel-control-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: auto;
+  z-index: 1001;
+  pointer-events: auto;
+}
+
+.carousel-control-prev {
+  left: 10px;
+}
+
+.carousel-control-next {
+  right:10px;
 }
 
 .modal {

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -186,27 +186,6 @@
   align-items: center;
 }
 
-// #gigbuddyModalCarousel {
-//   width: 100%;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-// }
-
-// #dogbnbCarousel {
-//   width: 100%;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-// }
-
-// #dogbnbModalCarousel {
-//   width: 100%;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-// }
-
 .carousel-inner {
   cursor: pointer;
   transition: transform 0.3s ease;
@@ -289,7 +268,6 @@
 .carousel-caption p {
   margin: 5px 0 0;
   font-size: 14px;
-  // color: $faint-pink;
   color: $white;
 }
 

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -172,20 +172,45 @@
 .carousel-container {
   width: 100%;
   max-width: 600px;
-  // height: 400px;
   margin: 20px auto;
   background-color: black;
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  // cursor: pointer;
   position: relative;
-  transition: transform 0.3s ease;
+  // transition: transform 0.3s ease;
 }
 
-.carousel-container:hover img {
+// .carousel-container:hover img {
+//   transform: scale(1.05);
+// }
+
+#gigbuddyCarousel {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#gigbuddyModalCarousel {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.carousel-inner {
+  cursor: pointer;
+  transition: transform 0.3s ease;
+  width: 90%;
+  // height: 100%;
+}
+
+.carousel-inner:hover img {
   transform: scale(1.05);
+  // border: none;
 }
 
 .carousel-item img {
@@ -193,22 +218,7 @@
   width: auto;
   object-fit: contain;
   background-color: black;
-  // cursor: pointer;
-  // transition: transform 0.3s ease;
-
-  // &:hover {
-  //   transform: scale(1.05);
-  // }
 }
-
-// .modal-body .carousel-item img:hover {
-//   transform: none;
-// }
-
-// .carousel-item:hover img {
-//   transform: scale(1.05);
-//   transition: transform 0.3s ease;
-// }
 
 .modal-body .carousel-item:hover img {
   transform: none;
@@ -233,15 +243,9 @@
 
 .modal {
   z-index: 10000;
-  // display: flex;
-  // align-items: center;
-  // justify-content: center;
 }
 
 .modal-body {
-  // display: flex;
-  // align-items: center;
-  // justify-content: center;
   background-color: black;
 
   img {
@@ -258,8 +262,6 @@
   left: 10px;
   text-align: left;
   padding: 10px;
-  // border-radius: 5px;
-  // background-color: rgba(0, 0, 0, 0.5);
 }
 
 .carousel-caption h5 {

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -175,6 +175,8 @@
   align-items: center;
   justify-content: center;
   position: relative;
+  border-radius: 3px;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 #gigbuddyCarousel, #gigbuddyModalCarousel, #dogbnbCarousel, #dogbnbModalCarousel {

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -169,6 +169,79 @@
   }
 }
 
+.carousel-container {
+  width: 100%;
+  max-width: 600px;
+  // height: 400px;
+  margin: 20px auto;
+  background-color: black;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.carousel-item img {
+  height: 400px;
+  width: auto;
+  object-fit: contain;
+  background-color: black;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+
+  &:hover {
+    transform: scale(1.05);
+  }
+}
+
+.modal {
+  z-index: 10000;
+  // display: flex;
+  // align-items: center;
+  // justify-content: center;
+}
+
+.modal-body {
+  // display: flex;
+  // align-items: center;
+  // justify-content: center;
+  background-color: black;
+
+  img {
+    max-width: 100%;
+    height: 80vh;
+    object-fit: contain;
+    background-color: black;
+  }
+}
+
+.carousel-caption.custom-caption {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  text-align: left;
+  padding: 10px;
+  // border-radius: 5px;
+  // background-color: rgba(0, 0, 0, 0.5);
+}
+
+.carousel-caption h5 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.carousel-caption p {
+  margin: 5px 0 0;
+  font-size: 14px;
+}
+// .carousel-control-prev-icon, .carousel-control-next-icon {
+//   filter: invert(100%);
+// }
+
+
+
+
+
 @media (max-width: 1000px) {
   .source-link {
     text-align: center;

--- a/app/assets/stylesheets/pages/_projects.scss
+++ b/app/assets/stylesheets/pages/_projects.scss
@@ -289,7 +289,8 @@
 .carousel-caption p {
   margin: 5px 0 0;
   font-size: 14px;
-  color: $faint-pink;
+  // color: $faint-pink;
+  color: $white;
 }
 
 .modal-header {

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-// import { Modal } from "bootstrap"
 
 // Connects to data-controller="carousel"
 export default class extends Controller {
@@ -7,7 +6,8 @@ export default class extends Controller {
 
   connect() {
     this.initializeCarousel();
-    this.syncCarousels();
+    this.syncCarouselsGigbuddy();
+    this.syncCarouselsDogbnb();
   }
 
   initializeCarousel() {
@@ -23,7 +23,7 @@ export default class extends Controller {
     modalCarousel.to(index);
   }
 
-  syncCarousels() {
+  syncCarouselsGigbuddy() {
     this.modalTarget.addEventListener("hidden.bs.modal", () => {
       this.cleanupModal();
       const activeIndex = Array.from(this.modalItemTargets).findIndex((item) =>
@@ -36,6 +36,24 @@ export default class extends Controller {
     this.modalCarouselTarget.addEventListener("slide.bs.carousel", event => {
       const mainCarousel = new bootstrap.Carousel(
         document.getElementById("gigbuddyCarousel")
+      );
+      mainCarousel.to(event.to);
+    });
+  }
+
+  syncCarouselsDogbnb() {
+    this.modalTarget.addEventListener("hidden.bs.modal", () => {
+      this.cleanupModal();
+      const activeIndex = Array.from(this.modalItemTargets).findIndex((item) =>
+        item.classList.contains("active")
+      );
+      const mainCarousel = new bootstrap.Carousel(document.getElementById("dogbnbCarousel")
+      );
+      mainCarousel.to(activeIndex);
+    });
+    this.modalCarouselTarget.addEventListener("slide.bs.carousel", event => {
+      const mainCarousel = new bootstrap.Carousel(
+        document.getElementById("dogbnbCarousel")
       );
       mainCarousel.to(event.to);
     });

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
 
   connect() {
     this.initializeCarousel();
+    this.syncCarousels();
   }
 
   initializeCarousel() {
@@ -18,7 +19,33 @@ export default class extends Controller {
   openModal(index) {
     const modalCarousel = new bootstrap.Carousel(this.modalCarouselTarget);
     this.modalItemTargets.forEach((item, idx) => item.classList.toggle("active", idx === index));
-    new Modal(this.modalTarget).show();
+    new bootstrap.Modal(this.modalTarget).show();
     modalCarousel.to(index);
+  }
+
+  syncCarousels() {
+    this.modalTarget.addEventListener("hidden.bs.modal", () => {
+      this.cleanupModal();
+      const activeIndex = Array.from(this.modalItemTargets).findIndex((item) =>
+        item.classList.contains("active")
+      );
+      const mainCarousel = new bootstrap.Carousel(document.getElementById("gigbuddyCarousel")
+      );
+      mainCarousel.to(activeIndex);
+    });
+    this.modalCarouselTarget.addEventListener("slide.bs.carousel", event => {
+      const mainCarousel = new bootstrap.Carousel(
+        document.getElementById("gigbuddyCarousel")
+      );
+      mainCarousel.to(event.to);
+    });
+  }
+
+  cleanupModal() {
+    const backdrops = document.querySelectorAll(".modal-backdrop");
+    backdrops.forEach((backdrop) => backdrop.remove());
+    document.body.classList.remove("modal-open");
+    document.body.style.removeProperty("overflow");
+    document.body.style.removeProperty("padding-right");
   }
 }

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
+
+// Connects to data-controller="carousel"
+export default class extends Controller {
+  static targets = ["image", "modal", "modalCarousel", "modalItem"];
+
+  connect() {
+    this.initializeCarousel();
+  }
+
+  initializeCarousel() {
+    this.imageTargets.forEach((img, index) => {
+      img.addEventListener("click", () => this.openModal(index));
+    });
+  }
+
+  openModal(index) {
+    const modalCarousel = new bootstrap.Carousel(this.modalCarouselTarget);
+    this.modalItemTargets.forEach((item, idx) => item.classList.toggle("active", idx === index));
+    new Modal(this.modalTarget).show();
+    modalCarousel.to(index);
+  }
+}

--- a/app/javascript/controllers/carousel_controller.js
+++ b/app/javascript/controllers/carousel_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { Modal } from "bootstrap"
+// import { Modal } from "bootstrap"
 
 // Connects to data-controller="carousel"
 export default class extends Controller {

--- a/app/views/pages/projects.html.erb
+++ b/app/views/pages/projects.html.erb
@@ -97,60 +97,62 @@
     <p><strong>-- Insert photo carousel of the app and features --</strong></p>
     <br>
 
-    <div class="carousel-container" data-controller="carousel">
+    <div class="carousel-container" data-controller="carousel" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
       <div id="gigbuddyCarousel" class="carousel slide" data-bs-ride="false">
         <div class="carousel-inner">
           <div class="carousel-item active" data-carousel-target="image">
-            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
           </div>
         </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="prev">
-          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Previous</span>
-        </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="next">
-          <span class="carousel-control-next-icon" aria-hidden="true"></span>
-          <span class="visually-hidden">Next</span>
-        </button>
+
       </div>
+      <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Previous</span>
+      </button>
+      <button class="carousel-control-next" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Next</span>
+      </button>
+
     </div>
 
 
 
-    <div class="modal fade" id="gigbuddyModal" tabindex="-1" aria-labelledby="gigbuddyModalLabel" aria-hidden="true" data-carousel-target="modal">
+    <div class="modal fade" id="gigbuddyModal" tabindex="-1" aria-labelledby="gigbuddyModalLabel" aria-hidden="true" data-controller="carousel">
       <div class="modal-dialog modal-xl">
         <div class="modal-content">
           <div class="modal-header">

--- a/app/views/pages/projects.html.erb
+++ b/app/views/pages/projects.html.erb
@@ -94,47 +94,45 @@
       <% end %>
     </div>
     <br>
-    <p><strong>-- Insert photo carousel of the app and features --</strong></p>
-    <br>
 
-    <div class="carousel-container" data-controller="carousel" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+    <div class="carousel-container" data-controller="carousel">
       <div id="gigbuddyCarousel" class="carousel slide" data-bs-ride="false">
-        <div class="carousel-inner">
+        <div class="carousel-inner" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
           <div class="carousel-item active" data-carousel-target="image">
-            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="TODO">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100 img-thumbnail" alt="TODO">
+            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="TODO">
           </div>
         </div>
 
@@ -148,112 +146,109 @@
         <span class="visually-hidden">Next</span>
       </button>
 
-    </div>
-
-
-
-    <div class="modal fade" id="gigbuddyModal" tabindex="-1" aria-labelledby="gigbuddyModalLabel" aria-hidden="true" data-controller="carousel">
-      <div class="modal-dialog modal-xl">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-          </div>
-          <div class="modal-body">
-            <div id="gigbuddyModalCarousel" class="carousel slide" data-bs-ride="false" data-carousel-target="modalCarousel">
-              <div class="carousel-inner">
-                <div class="carousel-item active" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_landing_page') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
+      <div class="modal fade" id="gigbuddyModal" tabindex="-1" aria-labelledby="gigbuddyModalLabel" aria-hidden="true" data-carousel-target="modal">
+        <div class="modal-dialog modal-xl">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <div id="gigbuddyModalCarousel" class="carousel slide" data-bs-ride="false" data-carousel-target="modalCarousel">
+                <div class="carousel-inner">
+                  <div class="carousel-item active" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_landing_page') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="TODO">
+                    <div class="carousel-caption custom-caption">
+                      <h5>img title</h5>
+                      <p>img description</p>
+                    </div>
                   </div>
                 </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
-                <div class="carousel-item" data-carousel-target="modalItem">
-                  <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="TODO">
-                  <div class="carousel-caption custom-caption">
-                    <h5>img title</h5>
-                    <p>img description</p>
-                  </div>
-                </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyModalCarousel" data-bs-slide="prev">
+                  <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                  <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#gigbuddyModalCarousel" data-bs-slide="next">
+                  <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                  <span class="visually-hidden">Next</span>
+                </button>
               </div>
-              <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyModalCarousel" data-bs-slide="prev">
-                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                <span class="visually-hidden">Previous</span>
-              </button>
-              <button class="carousel-control-next" type="button" data-bs-target="#gigbuddyModalCarousel" data-bs-slide="next">
-                <span class="carousel-control-next-icon" aria-hiddem="true"></span>
-                <span class="visually-hidden">Next</span>
-              </button>
             </div>
           </div>
         </div>

--- a/app/views/pages/projects.html.erb
+++ b/app/views/pages/projects.html.erb
@@ -94,7 +94,6 @@
       <% end %>
     </div>
     <br>
-
     <div class="carousel-container" data-controller="carousel">
       <div id="gigbuddyCarousel" class="carousel slide" data-bs-ride="false">
         <div class="carousel-inner" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
@@ -135,7 +134,6 @@
             <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy confirm to remove a match">
           </div>
         </div>
-
       </div>
       <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="prev">
         <span class="carousel-control-prev-icon" aria-hidden="true"></span>
@@ -145,7 +143,6 @@
         <span class="carousel-control-next-icon" aria-hidden="true"></span>
         <span class="visually-hidden">Next</span>
       </button>
-
       <div class="modal fade" id="gigbuddyModal" tabindex="-1" aria-labelledby="gigbuddyModalLabel" aria-hidden="true" data-carousel-target="modal">
         <div class="modal-dialog modal-xl">
           <div class="modal-content">
@@ -254,7 +251,6 @@
         </div>
       </div>
     </div>
-
   </div>
   <div class="projects-card">
     <h3>Dogbnb</h3>
@@ -300,7 +296,143 @@
       <% end %>
     </div>
     <br>
-    <p><strong>-- Insert photo carousel of site and features --</strong></p>
+    <div class="carousel-container" data-controller="carousel">
+      <div id="dogbnbCarousel" class="carousel slide" data-bs-ride="false">
+        <div class="carousel-inner" data-bs-toggle="modal" data-bs-target="#dogbnbModal">
+          <div class="carousel-item active" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_landing_page.png') %>" class="d-block w-100" alt="Screenshot of dogbnb landing page">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_login.png') %>" class="d-block w-100" alt="Screenshot of dogbnb login">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_search_bar.png') %>" class="d-block w-100" alt="Screenshot of dogbnb search bar">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_item_show.png') %>" class="d-block w-100" alt="Screenshot of dogbnb listing show page">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_reviews.png') %>" class="d-block w-100" alt="Screenshot of dogbnb listing's reviews">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_item_reserve.png') %>" class="d-block w-100" alt="Screenshot of dogbnb listing - place reservation">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_user_dropdown.png') %>" class="d-block w-100" alt="Screenshot of dogbnb user dropdown">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_view_bookings.png') %>" class="d-block w-100" alt="Screenshot of dogbnb view all your bookings">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_favorites_index.png') %>" class="d-block w-100" alt="Screenshot of dogbnb view all your favorites">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('dogbnb_list_new_item.png') %>" class="d-block w-100" alt="Screenshot of dogbnb create a new listing">
+          </div>
+        </div>
+      </div>
+      <button class="carousel-control-prev" type="button" data-bs-target="#dogbnbCarousel" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Previous</span>
+      </button>
+      <button class="carousel-control-next" type="button" data-bs-target="#dogbnbCarousel" data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Next</span>
+      </button>
+      <div class="modal fade" id="dogbnbModal" tabindex="-1" aria-labelledby="dogbnbModalLabel" aria-hidden="true" data-carousel-target="modal">
+        <div class="modal-dialog modal-xl">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <div id="dogbnbModalCarousel" class="carousel slide" data-bs-ride="false" data-carousel-target="modalCarousel">
+                <div class="carousel-inner">
+                  <div class="carousel-item active" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_landing_page.png') %>" class="d-block w-100" alt="Screenshot of dogbnb landing page">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>Landing Page</h5>
+                      <p>The view when a user first lands on the site</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_login.png') %>" class="d-block w-100" alt="Screenshot of dogbnb login">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>Login</h5>
+                      <p>Sign in or create an account for site</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_search_bar.png') %>" class="d-block w-100" alt="Screenshot of dogbnb search bar">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>Filter Options</h5>
+                      <p>Search for listing matching your requirements</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_item_show.png') %>" class="d-block w-100" alt="Screenshot of dogbnb listing show page">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>View a Listing</h5>
+                      <p>View more information about a listing</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_reviews.png') %>" class="d-block w-100" alt="Screenshot of dogbnb listing's reviews">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>View Reviews</h5>
+                      <p>Read through or leave a review for a listing</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_item_reserve.png') %>" class="d-block w-100" alt="Screenshot of dogbnb listing - place reservation">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>Make a Booking</h5>
+                      <p>Enter details and make a reservation</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_user_dropdown.png') %>" class="d-block w-100" alt="Screenshot of dogbnb user dropdown">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>Dropdown Options</h5>
+                      <p>Navigate the site</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_view_bookings.png') %>" class="d-block w-100" alt="Screenshot of dogbnb view all your bookings">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>View All Bookings</h5>
+                      <p>View all your placed bookings for reference</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_favorites_index.png') %>" class="d-block w-100" alt="Screenshot of dogbnb view all your favorites">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>View Favorites</h5>
+                      <p>Revisit listings you've favorited</p>
+                    </div>
+                  </div>
+                  <div class="carousel-item" data-carousel-target="modalItem">
+                    <img src="<%= asset_path('dogbnb_list_new_item.png') %>" class="d-block w-100" alt="Screenshot of dogbnb create a new listing">
+                    <div class="carousel-caption custom-caption-dogbnb">
+                      <h5>Create a Listing</h5>
+                      <p>Create a new listing for your own place for others to book!</p>
+                    </div>
+                  </div>
+                </div>
+                <button class="carousel-control-prev" type="button" data-bs-target="#dogbnbModalCarousel" data-bs-slide="prev">
+                  <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                  <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next" type="button" data-bs-target="#dogbnbModalCarousel" data-bs-slide="next">
+                  <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                  <span class="visually-hidden">Next</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="projects-card">
     <h3>LocalMarket</h3>

--- a/app/views/pages/projects.html.erb
+++ b/app/views/pages/projects.html.erb
@@ -99,40 +99,40 @@
       <div id="gigbuddyCarousel" class="carousel slide" data-bs-ride="false">
         <div class="carousel-inner" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
           <div class="carousel-item active" data-carousel-target="image">
-            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy landing page">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy view your profile page">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy edit your profile page">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy search for artists to add to profile">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy search results for artist search">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy alert to inform user of successfully adding artist to their profile">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy main swiper page">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy new match alert pop-up">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy view all my matches page">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy chatroom">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy view a match's profile page">
           </div>
           <div class="carousel-item" data-carousel-target="image">
-            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="TODO">
+            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy confirm to remove a match">
           </div>
         </div>
 
@@ -156,87 +156,87 @@
               <div id="gigbuddyModalCarousel" class="carousel slide" data-bs-ride="false" data-carousel-target="modalCarousel">
                 <div class="carousel-inner">
                   <div class="carousel-item active" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_landing_page') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_landing_page') %>" class="d-block w-100" alt="Screenshot of GigBuddy landing page">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Landing Page</h5>
+                      <p>The view when a user first opens the app</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy view your profile page">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>View Your Profile</h5>
+                      <p>Your profile view</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy edit your profile page">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Edit Your Profile</h5>
+                      <p>Edit any details on your profile or update your photo</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy search for artists to add to profile">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Search For Artists</h5>
+                      <p>Find more of your liked artists to add to your profile</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy search results for artist search">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Artists Search Results</h5>
+                      <p>The first 5 relevant artists matching your search</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy alert to inform user of successfully adding artist to their profile">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Success!</h5>
+                      <p>Alert when an action has been successful</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy main swiper page">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Main Swiper</h5>
+                      <p>Swipe through your potential matches</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy new match alert pop-up">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>New Match!</h5>
+                      <p>Displayed when a new connection is made</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy view all my matches page">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>View All Matches</h5>
+                      <p>List of all your matches - each is clickable</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy chatroom">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Chatroom</h5>
+                      <p>Chat with a match, visit their profile, or remove</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy view a match's profile page">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>View a Match's Profile Page</h5>
+                      <p>Explore a match's profile</p>
                     </div>
                   </div>
                   <div class="carousel-item" data-carousel-target="modalItem">
-                    <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="TODO">
+                    <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="Screenshot of GigBuddy confirm to remove a match">
                     <div class="carousel-caption custom-caption">
-                      <h5>img title</h5>
-                      <p>img description</p>
+                      <h5>Delete a Match</h5>
+                      <p>Confirm you definitely want to delete a match to prevent accidental removals!</p>
                     </div>
                   </div>
                 </div>

--- a/app/views/pages/projects.html.erb
+++ b/app/views/pages/projects.html.erb
@@ -40,7 +40,6 @@
     <div class="link-right">
       <%= link_to "https://github.com/BethGeast/beth-codes", target: "_blank", class: "source-link-extended" do %>
         View the source code <i class="fa-solid fa-laptop-code"></i>
-
       <% end %>
     </div>
   </div>
@@ -63,7 +62,6 @@
     <div class="link-right-extended">
       <%= link_to "https://www.youtube.com/watch?v=qJBE-69A08c", target: "_blank", class: "source-link-extended" do %>
         You can check out the recorded live demo of this on YouTube <i class="fa-brands fa-youtube"></i>
-        <%# <i class="fa-brands fa-youtube"></i> %>
       <% end %>
     </div>
     <h5>Technical Features:</h5>
@@ -93,11 +91,173 @@
       <% end %>
       <%= link_to "https://github.com/BethGeast/gig-buddy", target: "_blank", class: "source-link" do %>
         View the source code <i class="fa-solid fa-laptop-code"></i>
-
       <% end %>
     </div>
     <br>
     <p><strong>-- Insert photo carousel of the app and features --</strong></p>
+    <br>
+
+    <div class="carousel-container" data-controller="carousel">
+      <div id="gigbuddyCarousel" class="carousel slide" data-bs-ride="false">
+        <div class="carousel-inner">
+          <div class="carousel-item active" data-carousel-target="image">
+            <img src="<%= asset_path('gb_landing_page.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+          <div class="carousel-item" data-carousel-target="image">
+            <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100 img-thumbnail" alt="TODO" data-bs-toggle="modal" data-bs-target="#gigbuddyModal">
+          </div>
+        </div>
+        <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="prev">
+          <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Previous</span>
+        </button>
+        <button class="carousel-control-next" type="button" data-bs-target="#gigbuddyCarousel" data-bs-slide="next">
+          <span class="carousel-control-next-icon" aria-hidden="true"></span>
+          <span class="visually-hidden">Next</span>
+        </button>
+      </div>
+    </div>
+
+
+
+    <div class="modal fade" id="gigbuddyModal" tabindex="-1" aria-labelledby="gigbuddyModalLabel" aria-hidden="true" data-carousel-target="modal">
+      <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div id="gigbuddyModalCarousel" class="carousel slide" data-bs-ride="false" data-carousel-target="modalCarousel">
+              <div class="carousel-inner">
+                <div class="carousel-item active" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_landing_page') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_view_my_profile.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_edit_profile.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_search_artists.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_artist_search_results.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_success_alert.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_swiper.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_new_match.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_view_matches.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_chatroom.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_view_a_match.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+                <div class="carousel-item" data-carousel-target="modalItem">
+                  <img src="<%= asset_path('gb_delete_match_confirm.png') %>" class="d-block w-100" alt="TODO">
+                  <div class="carousel-caption custom-caption">
+                    <h5>img title</h5>
+                    <p>img description</p>
+                  </div>
+                </div>
+              </div>
+              <button class="carousel-control-prev" type="button" data-bs-target="#gigbuddyModalCarousel" data-bs-slide="prev">
+                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                <span class="visually-hidden">Previous</span>
+              </button>
+              <button class="carousel-control-next" type="button" data-bs-target="#gigbuddyModalCarousel" data-bs-slide="next">
+                <span class="carousel-control-next-icon" aria-hiddem="true"></span>
+                <span class="visually-hidden">Next</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
   <div class="projects-card">
     <h3>Dogbnb</h3>
@@ -137,11 +297,9 @@
     <div class="link-double">
       <%= link_to "https://github.com/BethGeast/DogBnB/blob/master/README.md", target: "_blank", class: "source-link-reverse" do %>
         <i class="fa-solid fa-file-code"></i> Read more about the app's features
-
       <% end %>
       <%= link_to "https://github.com/BethGeast/DogBnB", target: "_blank", class: "source-link" do %>
         View the source code <i class="fa-solid fa-laptop-code"></i>
-
       <% end %>
     </div>
     <br>
@@ -173,7 +331,6 @@
     <div class="link-right">
       <%= link_to "https://github.com/Joshjok86/localmarket", target: "_blank", class: "source-link-extended" do %>
         View the source code <i class="fa-solid fa-laptop-code"></i>
-
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Carousels and modals added for projects with screenshots to demonstrate front-end appearance of projects.
- Screenshots added for gigbuddy and dogbnb projects.
- Images displayed in a carousel, embedded in their respective project cards.
- When an image is clicked on, it opens a modal popup so the user can view the image clearer.
- User can continue to scroll through the carousel in this modal view.
- In the modal, the images include a title and description for what feature the image is of, for clarity.
- Carousel and modal synced: if user clicks through to image 3 before clicking to open modal, when modal opens, it will sync and also show image 3. If user continues to click through whilst in modal, goes to image 5 and then closes modal, the carousel in normal view will also display image 5. Each carousel is separately synced, so this will apply independently for gigbuddy and dogbnb carousels.
- Transform scale applied to image to encourage user, when they hover over the image, to click on it to open the modal view.
- Responsive design so should work and design be consistent across devices.
![image](https://github.com/user-attachments/assets/fb6d9df0-9fee-4838-ac42-a4db3b69dfe3)
![image](https://github.com/user-attachments/assets/23f84ba3-5b2a-4732-a641-14a71e92417d)
![image](https://github.com/user-attachments/assets/45f6b255-be3e-4d24-8870-0633ef978cf4)
![image](https://github.com/user-attachments/assets/c8cfe543-631b-42cd-af90-ef05b4c07d4b)
![image](https://github.com/user-attachments/assets/0143226a-6d17-4342-9186-6fb450fddd17)
![image](https://github.com/user-attachments/assets/4f5ab73b-e6c9-4e2f-8920-af5a521adf59)
![image](https://github.com/user-attachments/assets/5902d810-c1aa-4948-8945-802f6547d5a8)
